### PR TITLE
Downscope next release from 1.0 to 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdownlint-disable no-duplicate-heading -->
 
-## [1.0.0-dev]
+## [0.17.0-dev]
 
 ### Changed
 
@@ -94,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documentation fixes.
 
-[1.0.0-dev]: https://github.com/jdh8/dds-bridge/compare/0.16.0...main
+[0.17.0-dev]: https://github.com/jdh8/dds-bridge/compare/0.16.0...HEAD
 [0.16.0]: https://github.com/jdh8/dds-bridge/releases/tag/0.16.0
 [0.15.0]: https://github.com/jdh8/dds-bridge/releases/tag/0.15.0
 [0.14.0]: https://github.com/jdh8/dds-bridge/releases/tag/0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dds-bridge"
-version = "1.0.0-dev"
+version = "0.17.0-dev"
 authors = ["Chen-Pang He (https://jdh8.org)"]
 edition = "2024"
 rust-version = "1.85"

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -691,10 +691,7 @@ impl Solver {
     /// 2. `deals.len() * flags.bits().count_ones()` must not exceed
     ///    [`sys::MAXNOOFBOARDS`].
     ///
-    unsafe fn solve_deal_segment(
-        deals: &[Deal],
-        flags: StrainFlags,
-    ) -> sys::ddTablesRes {
+    unsafe fn solve_deal_segment(deals: &[Deal], flags: StrainFlags) -> sys::ddTablesRes {
         debug_assert!(
             deals.len() * flags.bits().count_ones() as usize <= sys::MAXNOOFBOARDS as usize
         );


### PR DESCRIPTION
The change set was too large for a 1.0 release, so the development
version and changelog heading are adjusted to target 0.17.0 instead.

https://claude.ai/code/session_0142WvefuPmAKK818xXG6pi5