### PR TITLE
Replace From<&[Card]> for PlayTraceBin with TryFrom + infallible ArrayVec variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- `PlayTraceBin::from(&[Card])` is replaced by `TryFrom<&[Card]>` (returns
+  `PlayTraceTooLong` when the slice exceeds 52 cards) and an infallible
+  `From<&ArrayVec<Card, 52>>` that the call sites now use. Both types remain
+  `pub(super)`; no public API change.
+
 ### Changed
 
 - **Breaking:** The trick-count types are renamed and gain a per-seat newtype:

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -348,7 +348,7 @@ impl Solver {
     #[must_use]
     pub fn analyse_play(&self, trace: PlayTrace) -> PlayAnalysis {
         let mut result = sys::solvedPlay::default();
-        let play: PlayTraceBin = trace.cards.as_slice().into();
+        let play = PlayTraceBin::from(&trace.cards);
         let status = unsafe { sys::AnalysePlayBin(trace.board.into(), play.0, &raw mut result, 0) };
         check(status);
         PlayAnalysis::from(result)
@@ -378,7 +378,7 @@ impl Solver {
         };
         traces.iter().enumerate().for_each(|(i, trace)| {
             pack.deals[i] = trace.board.clone().into();
-            plays.plays[i] = PlayTraceBin::from(trace.cards.as_slice()).0;
+            plays.plays[i] = PlayTraceBin::from(&trace.cards).0;
         });
         let mut res = sys::solvedPlays::default();
         let status =

--- a/src/solver/play.rs
+++ b/src/solver/play.rs
@@ -39,12 +39,21 @@ pub struct PlayTrace {
     pub cards: ArrayVec<Card, 52>,
 }
 
-/// Thin wrapper over [`sys::playTraceBin`] so we can impl `From<&[Card]>` for it
+/// Thin wrapper over [`sys::playTraceBin`] so we can impl conversions for it
 #[repr(transparent)]
 pub(super) struct PlayTraceBin(pub(super) sys::playTraceBin);
 
-impl From<&[Card]> for PlayTraceBin {
-    fn from(cards: &[Card]) -> Self {
+/// Error returned when a play trace exceeds the 52-card limit
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PlayTraceTooLong(pub(super) usize);
+
+impl TryFrom<&[Card]> for PlayTraceBin {
+    type Error = PlayTraceTooLong;
+
+    fn try_from(cards: &[Card]) -> Result<Self, Self::Error> {
+        if cards.len() > 52 {
+            return Err(PlayTraceTooLong(cards.len()));
+        }
         let mut play = sys::playTraceBin::default();
         #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
         {
@@ -54,7 +63,14 @@ impl From<&[Card]> for PlayTraceBin {
             play.suit[i] = 3 - card.suit as c_int;
             play.rank[i] = c_int::from(card.rank.get());
         }
-        Self(play)
+        Ok(Self(play))
+    }
+}
+
+impl From<&ArrayVec<Card, 52>> for PlayTraceBin {
+    fn from(cards: &ArrayVec<Card, 52>) -> Self {
+        // ArrayVec<Card, 52> is bounded to ≤ 52 elements, so this never fails.
+        Self::try_from(cards.as_slice()).unwrap()
     }
 }
 


### PR DESCRIPTION
The previous From<&[Card]> wrote into suit[52]/rank[52] arrays without a
bounds check; a slice longer than 52 cards would panic at the index site.

- Add TryFrom<&[Card]> for PlayTraceBin returning PlayTraceTooLong(usize)
  when len > 52, enforcing the invariant explicitly.
- Add infallible From<&ArrayVec<Card, 52>> that delegates to TryFrom and
  unwraps — the type bound already guarantees ≤ 52 elements.
- Update both call sites in solver.rs to pass &trace.cards directly,
  using the infallible path.

https://claude.ai/code/session_01SRjcH4eRZLjM3apJxwWCaC