### PR TITLE
feat: replace BoardError::Revoke index: u8 with RevokePosition enum (issue #3 A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `BoardError::Revoke` now carries `position: RevokePosition` instead of `index: u8`. The new `RevokePosition` enum has variants `Second`, `Third`, and `Fourth`, encoding the compile-time-bounded set of positions where a revoke can occur (the lead cannot revoke). Update match arms from `BoardError::Revoke { index: 1 }` / `index: 2` to `BoardError::Revoke { position: RevokePosition::Second }` / `RevokePosition::Third`.
+
 - **Breaking:** The trick-count types are renamed and gain a per-seat newtype:
   - `TricksRow` → `TrickCountRow`, `TricksTable` → `TrickCountTable` (and their `Hex` views).
   - New `TrickCount(u8)` newtype for a trick count in `0..=13`, analogous to `Level` / `Rank`. It provides `new`, `try_new`, `get() -> u8`, `Display`, and infallible `From<TrickCount>` for `u8` and `usize`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking:** `BoardError::Revoke` now carries `position: RevokePosition` instead of `index: u8`. The new `RevokePosition` enum has variants `Second`, `Third`, and `Fourth`, encoding the compile-time-bounded set of positions where a revoke can occur (the lead cannot revoke). Update match arms from `BoardError::Revoke { index: 1 }` / `index: 2` to `BoardError::Revoke { position: RevokePosition::Second }` / `RevokePosition::Third`.
-
 - **Breaking:** The trick-count types are renamed and gain a per-seat newtype:
   - `TricksRow` → `TrickCountRow`, `TricksTable` → `TrickCountTable` (and their `Hex` views).
   - New `TrickCount(u8)` newtype for a trick count in `0..=13`, analogous to `Level` / `Rank`. It provides `new`, `try_new`, `get() -> u8`, `Display`, and infallible `From<TrickCount>` for `u8` and `usize`.

--- a/src/solver/board.rs
+++ b/src/solver/board.rs
@@ -62,6 +62,30 @@ impl Target {
     }
 }
 
+/// Position of the revoking card within the current trick
+///
+/// The lead (first card) cannot revoke; these variants represent the
+/// subsequent seats in playing order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RevokePosition {
+    /// Second card of the trick (index 1)
+    Second,
+    /// Third card of the trick (index 2)
+    Third,
+    /// Fourth card of the trick (index 3)
+    Fourth,
+}
+
+impl core::fmt::Display for RevokePosition {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Second => f.write_str("second"),
+            Self::Third => f.write_str("third"),
+            Self::Fourth => f.write_str("fourth"),
+        }
+    }
+}
+
 /// Error returned when constructing a [`Board`] with invalid invariants
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -80,13 +104,10 @@ pub enum BoardError {
     )]
     InconsistentHandSizes,
     /// A played card does not follow suit though the player held the led suit
-    ///
-    /// `index` is the position within the current trick of the offending card
-    /// (always ≥ 1, since the lead itself cannot revoke).
-    #[error("Played card at index {index} is a revoke — player held the led suit")]
+    #[error("Played card at {position} position is a revoke — player held the led suit")]
     Revoke {
         /// Position of the revoking card within the current trick
-        index: u8,
+        position: RevokePosition,
     },
 }
 
@@ -275,9 +296,11 @@ impl Board {
             for (j, played_card) in current_trick.cards().iter().enumerate().skip(1) {
                 if played_card.suit != led_suit && !remaining[seats[j]][led_suit].is_empty() {
                     return Err(BoardError::Revoke {
-                        // `j < 3` constrained by `ArrayVec<Card, 3>`
-                        #[allow(clippy::cast_possible_truncation)]
-                        index: j as u8,
+                        position: match j {
+                            1 => RevokePosition::Second,
+                            2 => RevokePosition::Third,
+                            _ => RevokePosition::Fourth,
+                        },
                     });
                 }
             }

--- a/tests/solver.rs
+++ b/tests/solver.rs
@@ -527,7 +527,9 @@ fn board_try_new_detects_revoke_on_second_card() {
             remaining,
             CurrentTrick::from_slice(Strain::Notrump, Seat::North, &played).unwrap(),
         ),
-        Err(BoardError::Revoke { index: 1 })
+        Err(BoardError::Revoke {
+            position: RevokePosition::Second
+        })
     );
 }
 
@@ -582,7 +584,9 @@ fn board_try_new_detects_revoke_on_third_card() {
             remaining,
             CurrentTrick::from_slice(Strain::Notrump, Seat::North, &played).unwrap(),
         ),
-        Err(BoardError::Revoke { index: 2 })
+        Err(BoardError::Revoke {
+            position: RevokePosition::Third
+        })
     );
 }
 


### PR DESCRIPTION
Narrows the revoke-position payload from an unconstrained u8 to a new
`RevokePosition` enum (`Second`, `Third`, `Fourth`), making the valid
range `1..=3` a compile-time guarantee enforced by the type system.
The raw cast and the doc-comment-only invariant in `Board::try_new` are
replaced by an exhaustive match.  `BoardError::Revoke.position` field
name replaces `index`.

https://claude.ai/code/session_01KKWQkRjiCWoxY4c6SoM8Y2