### PR TITLE
Make par-decoding seat match exhaustive (TODO C1, issue #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- The `_` wildcard arm in the par-decoding seat match (`src/solver/par.rs`) is
+  replaced by an explicit `3 => Seat::West` arm followed by
+  `_ => unreachable!()`, so a malformed `contract.seats` value from DDS causes
+  an immediate panic instead of silently falling back to `Seat::West`.
 - `PlayTraceBin::from(&[Card])` is replaced by `TryFrom<&[Card]>` (returns
   `PlayTraceTooLong` when the slice exceeds 52 cards) and an infallible
   `From<&ArrayVec<Card, 52>>` that the call sites now use. Both types remain

--- a/src/solver/par.rs
+++ b/src/solver/par.rs
@@ -92,7 +92,8 @@ impl From<sys::parResultsMaster> for Par {
                     0 => Seat::North,
                     1 => Seat::East,
                     2 => Seat::South,
-                    _ => Seat::West,
+                    3 => Seat::West,
+                    _ => unreachable!("DDS returned an invalid seat value"),
                 };
                 let is_pair = contract.seats >= 4;
                 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]


### PR DESCRIPTION
Replace the `_ => Seat::West` wildcard arm with an explicit `3 => Seat::West` arm and `_ => unreachable!()`, so any malformed `contract.seats` value from DDS produces an immediate panic rather than silently mapping to West.

https://claude.ai/code/session_01ShK7bTp4o1oiizyo6iZY9E